### PR TITLE
CompatHelper: add new compat entry for LaTeXStrings at version 1, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ ShiftedArrays = "1277b4bf-5013-50f5-be3d-901d8477a67a"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
+LaTeXStrings = "1"
 julia = "1.11"
 
 [extras]


### PR DESCRIPTION
This pull request sets the compat entry for the `LaTeXStrings` package to `1`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.